### PR TITLE
chore: rename crate to bls_ringct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "sn_ringct"
+name = "bls_ringct"
 version = "0.1.0"
 readme = "README.md"
 license = "BSD-3-Clause"
-repository = "https://github.com/maidsafe/sn_ringct"
+repository = "https://github.com/maidsafe/bls_ringct"
 categories = ["cryptography"]
 keywords = ["cryptography", "crypto"]
 description = "A pure-Rust implementation of Ring Confidential Transactions"
 edition = "2021"
 
 [dependencies]
+bls_bulletproofs = "0.1.0"
+serde = { version = "1.0.130", optional = true }
 thiserror = "1"
 tiny-keccak = { version = "2.0", features = ["sha3"] }
-sn_bulletproofs = "0.1.0"
-serde = { version = "1.0.130", optional = true }
 
 [dev-dependencies]
 quickcheck = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("KeyImage is not on the BLS12-381 G1 Curve")]
     KeyImageNotOnCurve,
     #[error("BulletProofs Error: {0}")]
-    BulletProofs(#[from] sn_bulletproofs::ProofError),
+    BulletProofs(#[from] bls_bulletproofs::ProofError),
     #[error("The DBC transaction must have at least one input")]
     TransactionMustHaveAnInput,
     #[error("key image is not unique across all transaction inputs")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@ pub mod mlsag;
 pub mod ringct;
 
 // re-export deps used in our public API
+pub use bls_bulletproofs::{self, blstrs, group, rand};
 #[cfg(feature = "serde")]
 pub use serde;
-pub use sn_bulletproofs::{self, blstrs, group, rand};
 
-use sn_bulletproofs::{
+use bls_bulletproofs::{
     blstrs::{G1Projective, Scalar},
     group::{ff::Field, Group},
     rand::RngCore,

--- a/src/mlsag.rs
+++ b/src/mlsag.rs
@@ -1,4 +1,4 @@
-use sn_bulletproofs::{
+use bls_bulletproofs::{
     blstrs::{G1Affine, G1Projective, Scalar},
     group::{ff::Field, Curve, Group, GroupEncoding},
     rand::RngCore,

--- a/src/ringct.rs
+++ b/src/ringct.rs
@@ -1,4 +1,4 @@
-use sn_bulletproofs::{
+use bls_bulletproofs::{
     blstrs::{G1Affine, G1Projective, Scalar},
     group::ff::Field,
     group::Curve,


### PR DESCRIPTION
Yesterday we renamed this crate from blst_ringct to sn_ringct, but later we decided it would be
independent of Safe, so we'll rename again. We lose the 'sn' prefix in favour of 'bls', which drops
the 't' from the original name, since that's a specific implementation detail of the original
repository, which our fork has now diverged from. We also have other repos/crates that use this
'bls' prefix, so it brings it in line with those.

We also replace the `sn_bulletproofs` reference to `bls_bulletproofs`, which was a crate that was
also renamed.