### PR TITLE
chore: apply licensing consistently

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,6 @@ on:
     branches: [ master ]
 
 env:
-  CARGO_TERM_VERBOSE: true
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
 
@@ -38,6 +37,8 @@ jobs:
       - shell: bash
         run: cargo clippy --all-targets
 
+      - shell: bash
+        run: cargo install ripgrep
       - uses: maidsafe/verify-licensing-info@main
         name: verify licensing
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,3 @@ thiserror = "1"
   [dependencies.tiny-keccak]
   version = "2.0"
   features = [ "sha3" ]
-
-[dev-dependencies]
-quickcheck = "1"
-quickcheck_macros = "1"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021, MaidSafe
+Copyright (c) 2022, MaidSafe
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # blst-ringct
+
+A Rust implementation of Ring Confidential Transactions.
+
+## License
+
+This repository is licensed under the BSD-3-Clause license.
+
+See the [LICENSE](LICENSE) file for more details.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2022, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
 use thiserror::Error;
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2022, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
 pub mod error;
 pub mod mlsag;
 pub mod ringct;

--- a/src/mlsag.rs
+++ b/src/mlsag.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2022, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
 use bls_bulletproofs::{
     blstrs::{G1Affine, G1Projective, Scalar},
     group::{ff::Field, Curve, Group, GroupEncoding},

--- a/src/ringct.rs
+++ b/src/ringct.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2022, MaidSafe.
+// All rights reserved.
+//
+// This SAFE Network Software is licensed under the BSD-3-Clause license.
+// Please see the LICENSE file for more details.
+
 use bls_bulletproofs::{
     blstrs::{G1Affine, G1Projective, Scalar},
     group::ff::Field,


### PR DESCRIPTION
- 4c4cf66 **chore: apply licensing consistently**

  To get the licensing verification to pass, we have:
  * Installed ripgrep in the PR workflow for use with the licensing tool
  * Update the copyright attribution in the LICENSE 2022
  * Applied minimal copyright notice to Rust source files
  * Created a reference in to the LICENSE file in the README

  Other misc housekeeping:
  * Switch off verbose Cargo output in PR workflow as it makes the logs too hard to read
  * Removed unused dependency: quickcheck