### PR TITLE
chore: upgrade bls_bulletproofs to 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A pure-Rust implementation of Ring Confidential Transactions"
 edition = "2021"
 
 [dependencies]
-bls_bulletproofs = "0.2.0"
+bls_bulletproofs = "1.1.1"
 thiserror = "1"
 
   [dependencies.serde]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ pub struct RevealedCommitment {
 impl RevealedCommitment {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut v: Vec<u8> = Default::default();
-        v.extend(&self.value.to_le_bytes());
-        v.extend(&self.blinding.to_bytes_le());
+        v.extend(self.value.to_le_bytes());
+        v.extend(self.blinding.to_bytes_le());
         v
     }
 

--- a/src/mlsag.rs
+++ b/src/mlsag.rs
@@ -261,7 +261,7 @@ pub struct MlsagSignature {
 impl MlsagSignature {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut v: Vec<u8> = Default::default();
-        v.extend(&self.c0.to_bytes_le());
+        v.extend(self.c0.to_bytes_le());
         for (x, y) in self.r.iter() {
             v.extend(x.to_bytes_le());
             v.extend(y.to_bytes_le());


### PR DESCRIPTION
This is required to pull in a newer version of `blstrs` so there will only be one version of that crate in our dependency graph for `sn_dbc`.

Also fix a few misc clippy errors.